### PR TITLE
Animate multiple states in parallel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,2 @@
 node_modules
-.idea/.name
-
-.idea/atlassian-ide-plugin.xml
-
-.idea/dictionaries/janosveres.xml
-
-.idea/encodings.xml
-
-.idea/jsLibraryMappings.xml
-
-*.xml
-
-.idea/thi.iml
-
-.idea/vcs.xml
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,16 @@
 node_modules
+.idea/.name
+
+.idea/atlassian-ide-plugin.xml
+
+.idea/dictionaries/janosveres.xml
+
+.idea/encodings.xml
+
+.idea/jsLibraryMappings.xml
+
+*.xml
+
+.idea/thi.iml
+
+.idea/vcs.xml

--- a/README.md
+++ b/README.md
@@ -181,6 +181,63 @@ DemoCanvas.defaultProps = {
 }
 ```
 
+### Example 4. Multiple states in ReactART
+Set any state (e.g. 'x') associated with position left style
+```js:DemoCanvas.js
+
+import React from 'react'
+import ReactART from 'react-art'
+import Circle from 'react-art/lib/Circle.art.js'
+import ReactStateAnimation from 'react-state-animation'
+
+var Surface = ReactCanvas.Surface
+
+export default class DemoCanvas extends React.Component {
+    constructor(props) {
+        super(props)
+        this.state = {
+            x: props.position.x,
+            y: props.position.y,
+            radius: props.radius 
+        }
+        // react state animation wrapper
+        this._animate = new ReactStateAnimation(this)
+    }
+    
+    _Floating() {
+        // pass an array to the manimate method with the states, to be animated
+        this._animate.manimate([
+            /* state: 'theNameOfTheState', target: endValue */
+            {state: 'x', target: this.props.position.x-15},
+            {state: 'radius', target: this.props.radius+4}
+        ], 800, 'elasticInOut')
+        .then(() => this._animate.manimate([
+            {state: 'x', target: this.props.position.x},
+            {state: 'radius', target: this.props.radius-2}
+        ], 800, 'elasticInOut'))
+        .then(() => this._Floating());
+    }
+    
+    render() {
+        return (
+            <Surface ref="surface" top={0} left={0} width={this.props.canvasWidth} height={this.props.canvasHeight}>
+               <Circle radius={this.state.radius} fill="#fca500" x={this.state.x} y={this.state.y}  />
+            </Surface>
+        )
+    }
+}
+
+DemoCanvas.defaultProps = {
+    canvasWidth: 400,
+    canvasHeight: 300,
+    radius: 30,
+    position: {
+        x: 50,
+        y: 50
+    }
+}
+```
+
 ## Note
 React setState is now asynchronously called as a batch. So, using regular instance properties instaed of state seems faste especially for React Canvas.
 

--- a/src/Animate.js
+++ b/src/Animate.js
@@ -2,36 +2,36 @@ import Loop from './Loop'
 import {ease} from 'd3-ease'
 
 let eases = [
-  'linear-in',
-  'linear-out',
-  'linear-in-out',
-  'quad-in',
-  'quad-out',
-  'quad-in-out',
-  'cubic-in',
-  'cubic-out',
-  'cubic-in-out',
-  'poly-in',
-  'poly-out',
-  'poly-in-out',
-  'sin-in',
-  'sin-out',
-  'sin-in-out',
-  'exp-in',
-  'exp-out',
-  'exp-in-out',
-  'circle-in',
-  'circle-out',
-  'circle-in-out',
-  'bounce-in',
-  'bounce-out',
-  'bounce-in-out',
-  'back-in',
-  'back-out',
-  'back-in-out',
-  'elastic-in',
-  'elastic-out',
-  'elastic-in-out'
+    'linear-in',
+    'linear-out',
+    'linear-in-out',
+    'quad-in',
+    'quad-out',
+    'quad-in-out',
+    'cubic-in',
+    'cubic-out',
+    'cubic-in-out',
+    'poly-in',
+    'poly-out',
+    'poly-in-out',
+    'sin-in',
+    'sin-out',
+    'sin-in-out',
+    'exp-in',
+    'exp-out',
+    'exp-in-out',
+    'circle-in',
+    'circle-out',
+    'circle-in-out',
+    'bounce-in',
+    'bounce-out',
+    'bounce-in-out',
+    'back-in',
+    'back-out',
+    'back-in-out',
+    'elastic-in',
+    'elastic-out',
+    'elastic-in-out'
 ], Easing = {};
 
 /**
@@ -40,109 +40,184 @@ let eases = [
  */
 export default class Animate {
 
-  constructor(component) {
-    this._component = component;
+    constructor(component) {
+        this._component = component;
 
-    // generate an interface function for each ease.
-    eases.forEach( (e) => {
-      // convert to camelCase
-      var easeName = e.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
+        // generate an interface function for each ease.
+        eases.forEach( (e) => {
+            // convert to camelCase
+            var easeName = e.replace(/-([a-z])/g, function (g) { return g[1].toUpperCase(); });
 
-      // add instance methods dynamically
-      this[easeName] = function(prop, end, duration) {
-        return this.animate(prop, end, duration, easeName)
-      }
+            // add instance methods dynamically
+            this[easeName] = function(prop, end, duration) {
+                return this.animate(prop, end, duration, easeName)
+            }
 
-      Easing[easeName] = ease(e)
+            Easing[easeName] = ease(e)
 
-    });
-  }
-
-  /**
-   * Get state value
-   * if the prop is not in state regular property
-   */
-  _getStateValue(prop) {
-    var c = this._component,
-        v = c.state && c.state[prop]
-    return v === undefined ? c[prop] : v
-  }
-
-  /**
-   * Set value to state
-   * if the prop is not in state, set value to regular property with force update
-   */
-  _updateStateValue(prop, v) {
-    return new Promise((resolve, reject) => {
-      var c = this._component
-      if(c.state && c.state[prop] !== undefined){
-        var state = {}
-        state[prop] = v
-        c.setState(state, resolve)
-      }else{
-        c[prop] = v
-        c.forceUpdate()
-          resolve()
-      }
-    })
-  }
-
-  _start(loopCallback) {
-    this._loop = new Loop(loopCallback)
-      this._loop.start()
-  }
-
-  animate(prop, end, duration, easing) {
-    if(!Easing[easing]) {
-      console.log("Specified easing does not exist: " + easing)
-        return
+        });
     }
-    return new Promise((resolve, reject) => {
-      var begin = this._getStateValue(prop)
-        this._start(() => {
-          return this._anim(prop, begin, end, duration, easing, resolve)
+
+    /**
+     * Get state value
+     * if the prop is not in state regular property
+     */
+    _getStateValue(prop) {
+        var c = this._component,
+            v = c.state && c.state[prop]
+        return v === undefined ? c[prop] : v
+    }
+
+    /**
+     * Set value to state
+     * if the prop is not in state, set value to regular property with force update
+     */
+    _updateStateValue(prop, v) {
+        return new Promise((resolve, reject) => {
+            var c = this._component
+            if(c.state && c.state[prop] !== undefined){
+                var state = {}
+                state[prop] = v
+                c.setState(state, resolve)
+            }else{
+                c[prop] = v
+                c.forceUpdate()
+                resolve()
+            }
         })
-    })
-  }
-
-  // for override on each loop
-  onProcess(prop, value, progress) {
-  }
-
-  /**
-   * Start animation
-   *  - prop is a react state property
-   *  - end is a goal value of the state
-   */
-  _anim(prop, begin, end, duration, easing, resolve) {
-    if(!this._loop){
-      resolve()
-        return false
     }
-    var progress = Easing[easing](this._loop.timeDiff() / duration),
-        distance = Math.abs(begin - end),
-        diff = progress * distance,
-        operator = begin > end ? -1 : 1,
-        value = begin + diff * operator
-    this.onProcess(prop, value, progress)
-      if(progress < 1) {
-        // return promise to keep loop
-        return this._updateStateValue(prop, value)
-      }else{
-        this.stop()
-          this._updateStateValue(prop, end).then(() => {
+
+    /**
+     * Updates multiple properties within
+     * @param prop {Array} array of targeted states= {state: {string}, target: {number}}
+     * @param values {Array} array of values to be set
+     * @returns {Promise}
+     */
+    _updateStateMap(prop, values) {
+
+        return new Promise(function(resolve, reject) {
+            var c = this._component,
+                state = {};
+            // build up changed state
+            for(var i = 0; i < prop.length; i++) {
+                state[prop[i].state] = values[i];
+            }
+            c.setState(state, resolve);
+        });
+    }
+
+    _start(loopCallback) {
+        this._loop = new Loop(loopCallback)
+        this._loop.start()
+    }
+
+    animate(prop, end, duration, easing) {
+        if(!Easing[easing]) {
+            console.log("Specified easing does not exist: " + easing)
+            return
+        }
+        return new Promise((resolve, reject) => {
+            var begin = this._getStateValue(prop)
+            this._start(() => {
+                return this._anim(prop, begin, end, duration, easing, resolve)
+            })
+        })
+    }
+
+    manimate(prop, duration, easing) {
+        if (!Easing[easing]) {
+            console.log("Specified easing does not exist: " + easing);
+            return;
+        }
+        return new Promise(function(resolve, reject) {
+            // gather array begin States
+            var begins = [],
+                ends = [];
+            for(var i = 0; i < prop.length; i++) {
+                var b = this._getStateValue(prop[i].state);
+                var e = prop[i].target;
+                begins.push(b);
+                ends.push(e);
+            }
+            // start multi-anim
+            this._start(function() {
+                return this._multianim(prop, begins, ends, duration, easing, resolve);
+            });
+        });
+    }
+
+    // for override on each loop
+    onProcess(prop, value, progress) {
+    }
+
+    /**
+     * Start animation
+     *  - prop is a react state property
+     *  - end is a goal value of the state
+     */
+    _anim(prop, begin, end, duration, easing, resolve) {
+        if(!this._loop){
             resolve()
-          })
-          return false
-      }
-  }
-
-  stop() {
-    if(this._loop) {
-      this._loop.end()
-        this._loop = null
+            return false
+        }
+        var progress = Easing[easing](this._loop.timeDiff() / duration),
+            distance = Math.abs(begin - end),
+            diff = progress * distance,
+            operator = begin > end ? -1 : 1,
+            value = begin + diff * operator
+        this.onProcess(prop, value, progress)
+        if(progress < 1) {
+            // return promise to keep loop
+            return this._updateStateValue(prop, value)
+        }else{
+            this.stop()
+            this._updateStateValue(prop, end).then(() => {
+                resolve()
+            })
+            return false
+        }
     }
-    return this
-  }
+
+    _multianim(prop, begins, ends, duration, easing, resolve) {
+        if(!this._loop) {
+            resolve();
+            return false;
+        }
+        var progress = Easing[easing](this._loop.timeDiff() / duration),
+            newValues = [];
+
+        // step through all states
+        for(var i = 0; i < prop.length; i++) {
+            var begin = begins[i],
+                end = ends[i],
+                p = prop[i].state,
+                distance = Math.abs(begin - end),
+                diff = progress * distance,
+                operator = begin > end ? -1 : 1,
+                value = begin + diff * operator;
+
+            this.onProcess(p, value, progress);
+
+            newValues.push(value);
+        }
+
+        if(progress < 1) {
+            return this._updateStateMap(prop, newValues);
+        } else {
+            this.stop();
+            this._updateStateMap(prop, ends).then(function () {
+                resolve();
+            });
+            return false;
+        }
+    }
+
+    stop() {
+        if(this._loop) {
+            this._loop.end()
+            this._loop = null
+        }
+        return this
+    }
 
 }


### PR DESCRIPTION
Hey there,

When I found your code I was feeling super lucky! I've been looking for exactly this for the past couple of weeks with not so much luck. I added support for animating multiple states at once, because I needed it as well. If it makes sense to merge, I'm sharing it here.
Here's what I'm doing:

```
_Floating() {
        // pass an array to the manimate method with the states, to be animated
        this._animate.manimate([
            /* state: 'theNameOfTheState', target: endValue */
            {state: 'x', target: this.props.position.x-15},
            {state: 'radius', target: this.props.radius+4}
        ], 800, 'elasticInOut')
        .then(() => this._animate.manimate([
            {state: 'x', target: this.props.position.x},
            {state: 'radius', target: this.props.radius-2}
        ], 800, 'elasticInOut'))
        .then(() => this._Floating());
    }
```
